### PR TITLE
adding fallback to the content type (URLs only) into the Rabbit Hole

### DIFF
--- a/core/cat/rabbit_hole.py
+++ b/core/cat/rabbit_hole.py
@@ -161,7 +161,10 @@ class RabbitHole:
                 request = httpx.get(file, headers={"User-Agent": "Magic Browser"})
 
                 # Define mime type and source of url
-                content_type = request.headers["Content-Type"].split(";")[0]
+                # Add fallback for empty/None content_type
+                content_type = request.headers.get(
+                    "Content-Type", "text/html" if file.startswith(("http://", "https://")) else "text/plain"
+                ).split(";")[0]
                 source = file
 
                 try:
@@ -182,6 +185,10 @@ class RabbitHole:
 
         if not file_bytes:
             raise ValueError(f"Something went wrong with the file {source}")
+
+        log.debug(f"Attempting to parse file: {source}")
+        log.debug(f"Detected MIME type: {content_type}")
+        log.debug(f"Available handlers: {list(stray.file_handlers.keys())}")
 
         # Load the bytes in the Blob schema
         blob = Blob(data=file_bytes, mimetype=content_type).from_data(

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "Cheshire-Cat"
 description = "Production ready AI assistant framework"
-version = "2.1.2"
+version = "2.1.3"
 requires-python = ">=3.11"
 license = { file = "LICENSE" }
 authors = [


### PR DESCRIPTION
# Description

Adding a fallback in case the content type is not retrieved, when URLs are passed

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
