### PR TITLE
Use env port configuration in uvicorn

### DIFF
--- a/core/cat/main.py
+++ b/core/cat/main.py
@@ -27,7 +27,7 @@ if __name__ == "__main__":
     uvicorn.run(
         "cat.startup:cheshire_cat_api",
         host="0.0.0.0",
-        port=80,
+        port=int(get_env("CCAT_CORE_PORT")),
         use_colors=True,
         log_level=get_env("CCAT_LOG_LEVEL").lower(),
         **debug_config,


### PR DESCRIPTION
In linux ports lower than 1024 aren't available to users (they need root priviledge to be used).

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Related to issue #(issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
