### PR TITLE
Refactor: add route and logic to fetch conversation histories grouped by agent and user, update cruds for optional user inclusion

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,7 +15,7 @@ jobs:
     name: "Run linter"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: chartboost/ruff-action@v1
   test:
     name: "Run Tests"

--- a/cat/core_plugins/conversation_history/endpoints.py
+++ b/cat/core_plugins/conversation_history/endpoints.py
@@ -142,7 +142,7 @@ async def change_attribute_conversation(
     return PutConversationResponse(changed=True)
 
 
-# GET all conversations, in the format of IDs and names
+# GET all conversations of the picked user and the picked agent
 @endpoint.get(
     "/",
     response_model=List[GetConversationsResponse],
@@ -158,3 +158,25 @@ async def get_conversations(
     attributes_list = await crud_conversations.get_conversations_attributes(agent_id, user_id)
 
     return [GetConversationsResponse(**attributes_item) for attributes_item in attributes_list]
+
+
+# GET all conversations of the picked agent
+@endpoint.get(
+    "/",
+    response_model=Dict[str, List[GetConversationsResponse]],
+    tags=["Conversation"],
+    prefix="/agents/conversations",
+)
+async def get_conversations_by_agent(
+    info: AuthorizedInfo = check_permissions(AuthResource.MEMORY, AuthPermission.READ),
+) -> Dict[str, List[GetConversationsResponse]]:
+    """Get the specified user's conversation history from working memory"""
+    agent_id = info.cheshire_cat.agent_key
+    attributes_list = await crud_conversations.get_conversations_attributes(agent_id, "*", with_user=True)
+
+    grouped = {}
+    for attributes in attributes_list:
+        user_id = attributes.pop("user_id")
+        grouped.setdefault(user_id, []).append(GetConversationsResponse(**attributes))
+
+    return grouped

--- a/cat/db/cruds/conversations.py
+++ b/cat/db/cruds/conversations.py
@@ -66,7 +66,7 @@ async def get_conversation(agent_id: str, user_id: str, chat_id: str) -> Dict[st
         raise
 
 
-async def get_conversations_attributes(agent_id: str, user_id: str) -> List[Dict[str, Any]]:
+async def get_conversations_attributes(agent_id: str, user_id: str, with_user: bool = False) -> List[Dict[str, Any]]:
     """
     Retrieve conversations parameters from Redis.
 
@@ -75,10 +75,12 @@ async def get_conversations_attributes(agent_id: str, user_id: str) -> List[Dict
     Args:
         agent_id: ID of the chatbot.
         user_id: ID of the user.
+        with_user: Whether to include the user_id in the results (default: False).
 
     Returns:
         List of dictionaries, each one having the format
             {
+                "user_id": str,
                 "chat_id": str,
                 "name": str,
                 "num_messages": int,
@@ -114,15 +116,18 @@ async def get_conversations_attributes(agent_id: str, user_id: str) -> List[Dict
             conversation = raw[0] if isinstance(raw, list) else raw
             messages = conversation.get("messages", [])
             num_messages = len(messages)
-
-            results.append({
+            result = {
                 "chat_id": chat_id,
                 "name": conversation.get("name", chat_id),
                 "num_messages": num_messages,
                 "metadata": conversation.get("metadata", {}),
                 "created_at": messages[0]["when"] if num_messages > 0 else None,
                 "updated_at": messages[-1]["when"] if num_messages > 0 else None,
-            })
+            }
+            if with_user:
+                result["user_id"] = _user_id
+
+            results.append(result)
 
         return results
     except RedisError as e:

--- a/tests/routes/conversation/test_conversation.py
+++ b/tests/routes/conversation/test_conversation.py
@@ -347,6 +347,23 @@ async def test_get_conversations(secure_client, secure_client_headers, mocked_de
             assert item["num_messages"] == 4  # 2 mex + 2 replies
 
 
+async def test_get_conversations_by_agent(secure_client, secure_client_headers, mocked_default_llm_answer_prompt, cheshire_cat):
+    await test_get_conversations(secure_client, secure_client_headers, mocked_default_llm_answer_prompt, cheshire_cat)
+    user = await crud_users.get_user_by_username(agent_id, "user")
+
+    # check all the conversation histories by agent
+    response = await secure_client.get(
+        "/agents/conversations/", headers={**secure_client_headers, **{"X-User-ID": user["id"]}}
+    )
+    assert response.status_code == 200
+
+    json_response = response.json()
+    assert isinstance(json_response, dict)
+    assert len(json_response) == 1  # only one agent
+    assert user["id"] in json_response
+    assert len(json_response[user["id"]]) == 4
+
+
 async def test_get_conversation(secure_client, secure_client_headers, mocked_default_llm_answer_prompt, cheshire_cat):
     await create_new_user(
         secure_client,


### PR DESCRIPTION
# Description

Introduced a new endpoint /agents/conversations to retrieve the conversations of a given agent (identified by the X-Agent-ID header as usual), grouped per user_id

# Checklist:

- [x] I submitted my PR to branch `develop`
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run or added tests to cover my contribution
