### PR TITLE
Changed the order of parameter search to PATH -> QUERY -> HEADER

### DIFF
--- a/cat/auth/auth_utils.py
+++ b/cat/auth/auth_utils.py
@@ -48,15 +48,12 @@ def check_password(password: str, hashed: str) -> bool:
     except:
         return False
 
-
 def _extract_key_from_request(request: HTTPConnection, key: str, key_header: str) -> str:
-    return request.headers.get(
-        key_header,
-        request.path_params.get(
-            key,
-            request.query_params.get(key)
-        )
-    )
+    "look for a parameter for the first found in PATH -> QUERY -> HEADER order"
+    return request.path_params.get( key,
+           request.query_params.get(key,
+           request.headers.get(     key_header
+           )))
 
 
 def extract_agent_id_from_request(request: HTTPConnection) -> str | None:


### PR DESCRIPTION
# Description

The previous version was getting parameters from Headers even when the value was passed as a path parameter.
