### PR TITLE
when an entity is deleted Neo4J gives error if there are extra arguments

### DIFF
--- a/cat/looking_glass/cheshire_cat.py
+++ b/cat/looking_glass/cheshire_cat.py
@@ -362,7 +362,7 @@ class CheshireCat(BotMixin, NonCopyableMixin):
                 if points:
                     await self.vector_memory_handler.add_points_to_tenant(
                         collection_name=collection_name,
-                        points=[PointStruct(**p.model_dump()) for p in points],
+                        points=[PointStruct(**p.model_dump(exclude={"shard_key", "order_value"})) for p in points],
                     )
             success = True
         except Exception as e:


### PR DESCRIPTION
# Description

When the VectorDB of an agent is changed, the vectors are copied to GraphRAG, but extra arguments are not accepted, giving an error.

